### PR TITLE
Bugfix: Add notes_url to Manufacturers Read capabilities

### DIFF
--- a/internal/provider/data_source_manufacturers.go
+++ b/internal/provider/data_source_manufacturers.go
@@ -72,6 +72,11 @@ func dataSourceManufacturers() *schema.Resource {
 							Type:        schema.TypeString,
 							Required:    true,
 						},
+						"notes_url": {
+							Description: "Notes for manufacturer.",
+							Type:        schema.TypeString,
+							Optional:    true,
+						},
 						"platform_count": {
 							Description: "Manufacturer's platform count.",
 							Type:        schema.TypeInt,

--- a/internal/provider/data_source_manufacturers.go
+++ b/internal/provider/data_source_manufacturers.go
@@ -76,6 +76,7 @@ func dataSourceManufacturers() *schema.Resource {
 							Description: "Notes for manufacturer.",
 							Type:        schema.TypeString,
 							Optional:    true,
+							Computed:    true,
 						},
 						"platform_count": {
 							Description: "Manufacturer's platform count.",

--- a/internal/provider/resource_manufacturer.go
+++ b/internal/provider/resource_manufacturer.go
@@ -74,6 +74,7 @@ func resourceManufacturer() *schema.Resource {
 				Description: "Notes for manufacturer.",
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 			},
 			"platform_count": {
 				Description: "Manufacturer's platform count.",

--- a/internal/provider/resource_manufacturer.go
+++ b/internal/provider/resource_manufacturer.go
@@ -70,6 +70,11 @@ func resourceManufacturer() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"notes_url": {
+				Description: "Notes for manufacturer.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"platform_count": {
 				Description: "Manufacturer's platform count.",
 				Type:        schema.TypeInt,
@@ -199,6 +204,7 @@ func resourceManufacturerRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("description", item["description"].(string))
 	d.Set("display", item["display"].(string))
 	d.Set("id", item["id"].(string))
+	d.Set("notes_url", item["notes_url"].(string))
 	d.Set("slug", item["slug"].(string))
 	d.Set("url", item["url"].(string))
 	d.Set("last_updated", item["last_updated"].(string))


### PR DESCRIPTION
The `notes_url` was added in 1.4 and causes the fetching of Manufacturers to fail. This bugfix provides backwards compatibility.